### PR TITLE
Fixed block type check for SIGN in mixin

### DIFF
--- a/common/src/main/java/com/blackgear/platform/core/mixin/common/BlockEntityTypeMixin.java
+++ b/common/src/main/java/com/blackgear/platform/core/mixin/common/BlockEntityTypeMixin.java
@@ -18,7 +18,7 @@ public class BlockEntityTypeMixin {
     )
     @SuppressWarnings("EqualsBetweenInconvertibleTypes")
     private void platform$isValid(BlockState state, CallbackInfoReturnable<Boolean> cir) {
-        if (BlockEntityType.SIGN.equals(this) && (state.getBlock() instanceof SignBlock || state.getBlock() instanceof WallSignBlock)) {
+        if (BlockEntityType.SIGN.equals(this) && (state.getBlock() instanceof StandingSignBlock || state.getBlock() instanceof WallSignBlock)) {
             cir.setReturnValue(true);
         }
     }


### PR DESCRIPTION
SignBlock is the base class for every sign, even the hanging ones (which use another BlockEntityType). The correct check here is StandingSignBlock